### PR TITLE
Modify run_WE2E_tests.sh

### DIFF
--- a/tests/WE2E/run_WE2E_tests.sh
+++ b/tests/WE2E/run_WE2E_tests.sh
@@ -396,6 +396,16 @@ The argument \"machine\" specifying the machine or platform on which to
 run the WE2E tests was not specified in the call to this script.  \
 ${help_msg}"
 fi
+  # Cheyenne-specific test limitation
+
+if [ "${machine,,}" = "cheyenne" ]; then
+  use_cron_to_relaunch=FALSE
+  echo "
+Due to system limitations, the 'use_cron_to_relaunch' command can not be used on
+the '${machine}' machine. Setting this variable to false.
+
+"
+fi
 
 if [ -z "${account}" ]; then
   print_err_msg_exit "\
@@ -1298,6 +1308,38 @@ Could not generate an experiment for the test specified by test_name:
   test_name = \"${test_name}\""
 
 done
+
+# Print notes about monitoring/running jobs if use_cron_to_relaunch = FALSE
+topdir=${scrfunc_dir%/*/*/*}
+expt_dirs_fullpath="${topdir}/expt_dirs"
+
+echo "
+  ========================================================================
+  ========================================================================
+
+  All experiments have been generated in the directory
+  ${expt_dirs_fullpath}
+
+  ========================================================================
+  ========================================================================
+"
+
+if [ "${use_cron_to_relaunch,,}" = "false" ]; then
+  echo "
+
+The variable 'use_cron_to_relaunch' has been set to FALSE. Jobs will not be automatically run via crontab.
+
+You can run each task manually in the experiment directory:
+(${expt_dirs_fullpath})
+
+Or you can use the 'run_srw_tests.py' script in the ush/ directory:
+
+  cd $USHdir
+  ./run_srw_tests.py -e=${expt_dirs_fullpath}
+
+"
+fi
+
 #
 #-----------------------------------------------------------------------
 #


### PR DESCRIPTION
Updating Mark's PR since I don't have permission to push directly

https://github.com/ufs-community/ufs-srweather-app/pull/466

This commit modifies run_WE2E_tests.sh to include a few improvements to go along with the new run_srw_tests.py script:
    
   - When on Cheyenne, set use_cron_to_relaunch=false (since we should no longer use crontab to run batches of test on Cheyenne)
   - When use_cron_to_relaunch=false (regardless of machine), output a message at the end of the script describing how to run the new run_srw_tests.py script to manage the tests
   - Regardless of other variables, print a message at the end of the script showing the user where the test directory is
