### PR TITLE
Updated .cicd/scripts/srw_test.sh to work with ush/run_srw_tests.py

### DIFF
--- a/.cicd/scripts/srw_test.sh
+++ b/.cicd/scripts/srw_test.sh
@@ -40,12 +40,21 @@ fi
 cd ${we2e_test_dir}
 ./setup_WE2E_tests.sh ${platform} ${SRW_PROJECT} ${SRW_COMPILER} ${test_type} ${we2e_experiment_base_dir} ${nco_dir}
 
-# Allow the tests to start before checking for status.
-# TODO: Create a parameter that sets the initial start delay.
-sleep 300
+# Run the new run_srw_tests script if the machine is Cheyenne.
+if [[ "${platform}" = "cheyenne" ]]; then
+    cd ${workspace}/ush
+    ./run_srw_tests.py -e=${we2e_experiment_base_dir}
+    cd ${we2e_test_dir}
+fi
 
 # Progress file
 progress_file="${workspace}/we2e_test_results-${platform}-${SRW_COMPILER}.txt"
+
+# Allow the tests to start before checking for status.
+# TODO: Create a parameter that sets the initial start delay.
+if [[ "${platform}" != "cheyenne" ]]; then
+    sleep 300
+fi
 
 # Wait for all tests to complete.
 while true; do
@@ -72,10 +81,15 @@ done
 # TODO: Create parameter that sets the interval for the we2e cron jobs; this
 # value should be some factor of that interval to ensure the cron jobs execute
 # before the workspace is cleaned up.
-sleep 600
+if [[ "${platform}" != "cheyenne" ]]; then
+    sleep 600
+fi
 
 # Set exit code to number of failures
 set +e
 failures=$(grep "Workflow status:  FAILURE" ${progress_file} | wc -l)
+if [[ $failures -ne 0 ]]; then
+    failures=1
+fi
 set -e
 exit ${failures}


### PR DESCRIPTION
Updating Mark's PR since I don't have permission to push directly.

This commit modifies `.cicd/scripts/srw_test.sh` to work with `ush/run_srw_tests.py`:
* Add logic to launch the new run_srw_tests.py script in .cicd/scripts/srw_test.sh for Cheyenne.
* There is no need for the 300 and 600 sleep for Cheyenne now - added logic to only use this for the rest of the machines.
* If there is at least one FAILURE in the tests, the exit code will be set to 1.